### PR TITLE
feat: Add push notification support for chat events

### DIFF
--- a/common/src/main/kotlin/com/cpcjrcoding/chirp/infra/messagequeue/MessageQueues.kt
+++ b/common/src/main/kotlin/com/cpcjrcoding/chirp/infra/messagequeue/MessageQueues.kt
@@ -2,5 +2,6 @@ package com.cpcjrcoding.chirp.infra.messagequeue
 
 object MessageQueues {
     const val NOTIFICATION_USER_EVENTS = "notification.user.events"
+    const val NOTIFICATION_CHAT_EVENTS = "notification.chat.events"
     const val CHAT_USER_EVENTS = "chat.user.events"
 }

--- a/common/src/main/kotlin/com/cpcjrcoding/chirp/infra/messagequeue/RabbitMqConfig.kt
+++ b/common/src/main/kotlin/com/cpcjrcoding/chirp/infra/messagequeue/RabbitMqConfig.kt
@@ -1,6 +1,7 @@
 package com.cpcjrcoding.chirp.infra.messagequeue
 
 import com.cpcjrcoding.chirp.domain.events.ChirpEvent
+import com.cpcjrcoding.chirp.domain.events.chat.ChatEvent
 import com.cpcjrcoding.chirp.domain.events.chat.ChatEventConstants
 import com.cpcjrcoding.chirp.domain.events.user.UserEventConstants
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -17,6 +18,7 @@ import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.transaction.annotation.EnableTransactionManagement
+import java.awt.EventQueue
 
 @Configuration
 @EnableTransactionManagement
@@ -85,6 +87,23 @@ class RabbitMqConfig {
             MessageQueues.NOTIFICATION_USER_EVENTS,
             true,
         )
+
+    @Bean
+    fun notificationChatEventsQueue() =
+        Queue(
+            MessageQueues.NOTIFICATION_CHAT_EVENTS,
+            true,
+        )
+
+    @Bean
+    fun notificationChatEventsBinding(
+        notificationChatEventsQueue: Queue,
+        chatExchange: TopicExchange,
+    ): Binding =
+        BindingBuilder
+            .bind(notificationChatEventsQueue)
+            .to(chatExchange)
+            .with(ChatEventConstants.CHAT_NEW_MESSAGE)
 
     @Bean
     fun notificationUserEventsBinding(

--- a/notification/build.gradle.kts
+++ b/notification/build.gradle.kts
@@ -16,9 +16,15 @@ dependencies {
 
     implementation(libs.firebase.admin.sdk)
 
+    implementation(libs.spring.boot.starter.web)
     implementation(libs.spring.boot.starter.amqp)
     implementation(libs.spring.boot.starter.mail)
     implementation(libs.spring.boot.starter.thymeleaf)
+    implementation(libs.spring.boot.starter.validation)
+    implementation(libs.spring.boot.starter.data.jpa)
+
+    runtimeOnly(libs.postgresql)
+
     testImplementation(kotlin("test"))
 }
 

--- a/notification/src/main/kotlin/com/cpcjrcoding/chirp/api/controllers/DeviceTokenController.kt
+++ b/notification/src/main/kotlin/com/cpcjrcoding/chirp/api/controllers/DeviceTokenController.kt
@@ -1,0 +1,39 @@
+package com.cpcjrcoding.chirp.api.controllers
+
+import com.cpcjrcoding.chirp.api.dto.DeviceTokenDto
+import com.cpcjrcoding.chirp.api.dto.RegisterDeviceRequest
+import com.cpcjrcoding.chirp.api.mappers.toDeviceTokenDto
+import com.cpcjrcoding.chirp.api.mappers.toPlatformDto
+import com.cpcjrcoding.chirp.api.util.requestUserId
+import com.cpcjrcoding.chirp.service.PushNotificationService
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/notification")
+class DeviceTokenController(
+    private val pushNotificationService: PushNotificationService,
+) {
+    @PostMapping("/register")
+    fun registerDeviceToken(
+        @Valid @RequestBody body: RegisterDeviceRequest,
+    ): DeviceTokenDto =
+        pushNotificationService
+            .registerDevice(
+                userId = requestUserId,
+                token = body.token,
+                platform = body.platform.toPlatformDto(),
+            ).toDeviceTokenDto()
+
+    @DeleteMapping("/{token}")
+    fun unregisterDeviceToken(
+        @PathVariable("token") token: String,
+    ) {
+        pushNotificationService.unregisterDevice(token)
+    }
+}

--- a/notification/src/main/kotlin/com/cpcjrcoding/chirp/api/dto/DeviceTokenDto.kt
+++ b/notification/src/main/kotlin/com/cpcjrcoding/chirp/api/dto/DeviceTokenDto.kt
@@ -1,0 +1,10 @@
+package com.cpcjrcoding.chirp.api.dto
+
+import com.cpcjrcoding.chirp.domain.type.UserId
+import java.time.Instant
+
+data class DeviceTokenDto(
+    val userId: UserId,
+    val token: String,
+    val createdAt: Instant,
+)

--- a/notification/src/main/kotlin/com/cpcjrcoding/chirp/api/dto/RegisterDeviceRequest.kt
+++ b/notification/src/main/kotlin/com/cpcjrcoding/chirp/api/dto/RegisterDeviceRequest.kt
@@ -1,0 +1,14 @@
+package com.cpcjrcoding.chirp.api.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class RegisterDeviceRequest(
+    @field:NotBlank
+    val token: String,
+    val platform: PlatformDto,
+)
+
+enum class PlatformDto {
+    ANDROID,
+    IOS,
+}

--- a/notification/src/main/kotlin/com/cpcjrcoding/chirp/api/exceptionhandling/NotificationExceptionHandler.kt
+++ b/notification/src/main/kotlin/com/cpcjrcoding/chirp/api/exceptionhandling/NotificationExceptionHandler.kt
@@ -1,0 +1,18 @@
+package com.cpcjrcoding.chirp.api.exceptionhandling
+
+import com.cpcjrcoding.chirp.domain.exception.InvalidDeviceTokenException
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class NotificationExceptionHandler {
+    @ExceptionHandler(InvalidDeviceTokenException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun onInvalidDeviceToken(e: InvalidDeviceTokenException) =
+        mapOf(
+            "code" to "INVALID_DEVICE_TOKEN",
+            "message" to e.message,
+        )
+}

--- a/notification/src/main/kotlin/com/cpcjrcoding/chirp/api/mappers/DeviceTokenMappers.kt
+++ b/notification/src/main/kotlin/com/cpcjrcoding/chirp/api/mappers/DeviceTokenMappers.kt
@@ -1,0 +1,18 @@
+package com.cpcjrcoding.chirp.api.mappers
+
+import com.cpcjrcoding.chirp.api.dto.DeviceTokenDto
+import com.cpcjrcoding.chirp.api.dto.PlatformDto
+import com.cpcjrcoding.chirp.domain.model.DeviceToken
+
+fun DeviceToken.toDeviceTokenDto(): DeviceTokenDto =
+    DeviceTokenDto(
+        userId = userId,
+        token = token,
+        createdAt = createdAt,
+    )
+
+fun PlatformDto.toPlatformDto(): DeviceToken.Platform =
+    when (this) {
+        PlatformDto.ANDROID -> DeviceToken.Platform.ANDROID
+        PlatformDto.IOS -> DeviceToken.Platform.IOS
+    }

--- a/notification/src/main/kotlin/com/cpcjrcoding/chirp/domain/exception/InvalidDeviceTokenException.kt
+++ b/notification/src/main/kotlin/com/cpcjrcoding/chirp/domain/exception/InvalidDeviceTokenException.kt
@@ -1,0 +1,3 @@
+package com.cpcjrcoding.chirp.domain.exception
+
+class InvalidDeviceTokenException : RuntimeException("Invalid device token.")

--- a/notification/src/main/kotlin/com/cpcjrcoding/chirp/infra/database/DeviceTokenEntity.kt
+++ b/notification/src/main/kotlin/com/cpcjrcoding/chirp/infra/database/DeviceTokenEntity.kt
@@ -1,0 +1,38 @@
+package com.cpcjrcoding.chirp.infra.database
+
+import com.cpcjrcoding.chirp.domain.type.UserId
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import java.time.Instant
+
+@Entity
+@Table(
+    name = "device_tokens",
+    schema = "notification_service",
+    indexes = [
+        Index(name = "idx_device_tokens_user_id", columnList = "user_id"),
+        Index(name = "idx_device_tokens_token", columnList = "token", unique = true),
+    ],
+)
+class DeviceTokenEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0,
+    @Column(nullable = false)
+    var userId: UserId,
+    @Column(nullable = false)
+    var token: String,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var platform: PlatformEntity,
+    @CreationTimestamp
+    var createdAt: Instant = Instant.now(),
+)

--- a/notification/src/main/kotlin/com/cpcjrcoding/chirp/infra/database/DeviceTokenRepository.kt
+++ b/notification/src/main/kotlin/com/cpcjrcoding/chirp/infra/database/DeviceTokenRepository.kt
@@ -1,0 +1,12 @@
+package com.cpcjrcoding.chirp.infra.database
+
+import com.cpcjrcoding.chirp.domain.type.UserId
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface DeviceTokenRepository : JpaRepository<DeviceTokenEntity, Long> {
+    fun findByUserIdIn(userIds: List<UserId>): List<DeviceTokenEntity>
+
+    fun findByToken(token: String): DeviceTokenEntity?
+
+    fun deleteByToken(token: String)
+}

--- a/notification/src/main/kotlin/com/cpcjrcoding/chirp/infra/database/PlatformEntity.kt
+++ b/notification/src/main/kotlin/com/cpcjrcoding/chirp/infra/database/PlatformEntity.kt
@@ -1,0 +1,6 @@
+package com.cpcjrcoding.chirp.infra.database
+
+enum class PlatformEntity {
+    ANDROID,
+    IOS,
+}

--- a/notification/src/main/kotlin/com/cpcjrcoding/chirp/infra/mappers/DeviceTokenMappers.kt
+++ b/notification/src/main/kotlin/com/cpcjrcoding/chirp/infra/mappers/DeviceTokenMappers.kt
@@ -1,0 +1,13 @@
+package com.cpcjrcoding.chirp.infra.mappers
+
+import com.cpcjrcoding.chirp.domain.model.DeviceToken
+import com.cpcjrcoding.chirp.infra.database.DeviceTokenEntity
+
+fun DeviceTokenEntity.toDeviceToken(): DeviceToken =
+    DeviceToken(
+        userId = userId,
+        token = token,
+        platform = platform.toPlatform(),
+        createdAt = createdAt,
+        id = id,
+    )

--- a/notification/src/main/kotlin/com/cpcjrcoding/chirp/infra/mappers/PlatformMappers.kt
+++ b/notification/src/main/kotlin/com/cpcjrcoding/chirp/infra/mappers/PlatformMappers.kt
@@ -1,0 +1,16 @@
+package com.cpcjrcoding.chirp.infra.mappers
+
+import com.cpcjrcoding.chirp.domain.model.DeviceToken
+import com.cpcjrcoding.chirp.infra.database.PlatformEntity
+
+fun DeviceToken.Platform.toPlatformEntity(): PlatformEntity =
+    when (this) {
+        DeviceToken.Platform.ANDROID -> PlatformEntity.ANDROID
+        DeviceToken.Platform.IOS -> PlatformEntity.IOS
+    }
+
+fun PlatformEntity.toPlatform(): DeviceToken.Platform =
+    when (this) {
+        PlatformEntity.ANDROID -> DeviceToken.Platform.ANDROID
+        PlatformEntity.IOS -> DeviceToken.Platform.IOS
+    }

--- a/notification/src/main/kotlin/com/cpcjrcoding/chirp/infra/messagequeue/NotificationChatEventListener.kt
+++ b/notification/src/main/kotlin/com/cpcjrcoding/chirp/infra/messagequeue/NotificationChatEventListener.kt
@@ -1,0 +1,26 @@
+package com.cpcjrcoding.chirp.infra.messagequeue
+
+import com.cpcjrcoding.chirp.domain.events.chat.ChatEvent
+import com.cpcjrcoding.chirp.service.PushNotificationService
+import org.springframework.amqp.rabbit.annotation.RabbitListener
+import org.springframework.stereotype.Component
+
+@Component
+class NotificationChatEventListener(
+    private val pushNotificationService: PushNotificationService,
+) {
+    @RabbitListener(queues = [MessageQueues.NOTIFICATION_CHAT_EVENTS])
+    fun handleUserEvent(event: ChatEvent) {
+        when (event) {
+            is ChatEvent.NewMessage -> {
+                pushNotificationService.sendNewMessageNotifications(
+                    recipientUserIds = event.recipientIds.toList(),
+                    senderUserId = event.senderId,
+                    senderUsername = event.senderUsername,
+                    message = event.message,
+                    chatId = event.chatId,
+                )
+            }
+        }
+    }
+}

--- a/notification/src/main/kotlin/com/cpcjrcoding/chirp/service/PushNotificationService.kt
+++ b/notification/src/main/kotlin/com/cpcjrcoding/chirp/service/PushNotificationService.kt
@@ -1,0 +1,201 @@
+package com.cpcjrcoding.chirp.service
+
+import com.cpcjrcoding.chirp.domain.exception.InvalidDeviceTokenException
+import com.cpcjrcoding.chirp.domain.model.DeviceToken
+import com.cpcjrcoding.chirp.domain.model.PushNotification
+import com.cpcjrcoding.chirp.domain.type.ChatId
+import com.cpcjrcoding.chirp.domain.type.UserId
+import com.cpcjrcoding.chirp.infra.database.DeviceTokenEntity
+import com.cpcjrcoding.chirp.infra.database.DeviceTokenRepository
+import com.cpcjrcoding.chirp.infra.mappers.toDeviceToken
+import com.cpcjrcoding.chirp.infra.mappers.toPlatformEntity
+import com.cpcjrcoding.chirp.infra.pushnotification.FirebasePushNotificationService
+import jakarta.transaction.Transactional
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.ConcurrentSkipListMap
+
+@Service
+class PushNotificationService(
+    private val deviceTokenRepository: DeviceTokenRepository,
+    private val firebasePushNotificationService: FirebasePushNotificationService,
+) {
+    companion object {
+        private val RETRY_DELAYS_SECONDS =
+            listOf(
+                30L,
+                60L,
+                120L,
+                300L,
+                600L,
+            )
+        const val MAX_RETRY_AGE_MINUTES = 30L
+    }
+
+    private val retryQueue = ConcurrentSkipListMap<Long, MutableList<RetryData>>()
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Transactional
+    fun registerDevice(
+        userId: UserId,
+        token: String,
+        platform: DeviceToken.Platform,
+    ): DeviceToken {
+        val existing = deviceTokenRepository.findByToken(token)
+
+        val trimmedToken = token.trim()
+        if (existing == null && !firebasePushNotificationService.isValidToken(trimmedToken)) {
+            throw InvalidDeviceTokenException()
+        }
+
+        val entity =
+            if (existing != null) {
+                deviceTokenRepository.save(
+                    existing.apply {
+                        this.userId = userId
+                    },
+                )
+            } else {
+                deviceTokenRepository.save(
+                    DeviceTokenEntity(
+                        userId = userId,
+                        token = trimmedToken,
+                        platform = platform.toPlatformEntity(),
+                    ),
+                )
+            }
+
+        return entity.toDeviceToken()
+    }
+
+    @Transactional
+    fun unregisterDevice(token: String) {
+        deviceTokenRepository.deleteByToken(token.trim())
+    }
+
+    fun sendNewMessageNotifications(
+        recipientUserIds: List<UserId>,
+        senderUserId: UserId,
+        senderUsername: String,
+        message: String,
+        chatId: ChatId,
+    ) {
+        val deviceTokens = deviceTokenRepository.findByUserIdIn(recipientUserIds)
+        if (deviceTokens.isEmpty()) {
+            logger.info("No device tokens found for $recipientUserIds")
+            return
+        }
+
+        val recipients =
+            deviceTokens
+                .filter { it.userId != senderUserId }
+                .map { it.toDeviceToken() }
+
+        val notification =
+            PushNotification(
+                title = "New message from $senderUsername",
+                recipients = recipients,
+                message = message,
+                chatId = chatId,
+                data =
+                    mapOf(
+                        "chatId" to chatId.toString(),
+                        "type" to "new_message",
+                    ),
+            )
+
+        firebasePushNotificationService.sendNotification(notification)
+    }
+
+    fun sendWithRetry(
+        notification: PushNotification,
+        attempt: Int = 0,
+    ) {
+        val result = firebasePushNotificationService.sendNotification(notification)
+
+        result.permanentFailures.forEach {
+            deviceTokenRepository.deleteByToken(it.token)
+        }
+
+        if (result.temporaryFailures.isNotEmpty() && attempt < RETRY_DELAYS_SECONDS.size) {
+            val retryNotification =
+                notification.copy(
+                    recipients = result.temporaryFailures,
+                )
+            scheduleRetry(retryNotification, attempt + 1)
+        }
+
+        if (result.succeeded.isNotEmpty()) {
+            logger.info("Successfully sent notification to ${result.succeeded.size} devices")
+        }
+    }
+
+    private fun scheduleRetry(
+        notification: PushNotification,
+        attempt: Int,
+    ) {
+        val delay =
+            RETRY_DELAYS_SECONDS.getOrElse(attempt - 1) {
+                RETRY_DELAYS_SECONDS.last()
+            }
+        val executeAt = Instant.now().plusSeconds(delay)
+        val executeAtMillis = executeAt.toEpochMilli()
+
+        val retryData =
+            RetryData(
+                notification = notification,
+                attempt = attempt,
+                createdAt = Instant.now(),
+            )
+
+        retryQueue.compute(executeAtMillis) { _, retries ->
+            (retries ?: mutableListOf()).apply { add(retryData) }
+        }
+
+        logger.info("Scheduled retry $attempt for ${notification.id} in $delay seconds")
+    }
+
+    @Scheduled(fixedDelay = 15_000L)
+    fun processRetries() {
+        val now = Instant.now()
+        val nowMillis = now.toEpochMilli()
+
+        val toProcess = retryQueue.headMap(nowMillis, true)
+
+        if (toProcess.isEmpty()) {
+            return
+        }
+
+        val entries = toProcess.entries.toList()
+        entries.forEach { (timeMillis, retries) ->
+            retryQueue.remove(timeMillis)
+
+            retries.forEach { retry ->
+                try {
+                    val age = Duration.between(retry.createdAt, now)
+                    if (age.toMinutes() > MAX_RETRY_AGE_MINUTES) {
+                        logger.warn("Dropping old retry (${age.toMinutes()} old)")
+                        return@forEach
+                    }
+
+                    sendWithRetry(
+                        notification = retry.notification,
+                        attempt = retry.attempt,
+                    )
+                } catch (e: Exception) {
+                    logger.warn("Error processing retry ${retry.notification.id}", e)
+                }
+            }
+        }
+    }
+
+    private data class RetryData(
+        val notification: PushNotification,
+        val attempt: Int,
+        val createdAt: Instant,
+    )
+}


### PR DESCRIPTION
* Introduces device token registration and management, database entities, and mappers for notification service.
* Adds RabbitMQ queue and binding for chat events, a listener for new chat messages, and integrates push notification sending with retry logic.
* Updates dependencies to support web, validation, JPA, and PostgreSQL.