### PR TITLE
update: Add ChatCreatedEvent and refactor cache eviction

### DIFF
--- a/chat/src/main/kotlin/com/cpcjrcoding/chirp/api/websocket/ChatWebSocketHandler.kt
+++ b/chat/src/main/kotlin/com/cpcjrcoding/chirp/api/websocket/ChatWebSocketHandler.kt
@@ -10,6 +10,7 @@ import com.cpcjrcoding.chirp.api.dto.ws.OutgoingWebSocketMessageType
 import com.cpcjrcoding.chirp.api.dto.ws.ProfilePictureUpdateDto
 import com.cpcjrcoding.chirp.api.dto.ws.SendMessageDto
 import com.cpcjrcoding.chirp.api.mappers.toChatMessageDto
+import com.cpcjrcoding.chirp.domain.events.ChatCreatedEvent
 import com.cpcjrcoding.chirp.domain.events.ChatParticipantLeftEvent
 import com.cpcjrcoding.chirp.domain.events.ChatParticipantsJoinedEvent
 import com.cpcjrcoding.chirp.domain.events.MessageDeletedEvent
@@ -203,23 +204,41 @@ class ChatWebSocketHandler(
         )
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    fun onJoinChat(event: ChatParticipantsJoinedEvent) {
+    private fun updateChatForUsers(
+        chatId: ChatId,
+        userIds: List<UserId>,
+    ) {
         connectionLock.write {
-            event.userIds.forEach { userId ->
+            userIds.forEach { userId ->
                 userChatIds.compute(userId) { _, chatIds ->
                     (chatIds ?: mutableSetOf()).apply {
-                        add(event.chatId)
+                        add(chatId)
                     }
                 }
 
                 userToSessions[userId]?.forEach { sessionId ->
-                    chatToSessions.compute(event.chatId) { _, sessions ->
+                    chatToSessions.compute(chatId) { _, sessions ->
                         (sessions ?: mutableSetOf()).apply { add(sessionId) }
                     }
                 }
             }
         }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun onChatCreated(event: ChatCreatedEvent) {
+        updateChatForUsers(
+            chatId = event.chatId,
+            userIds = event.participantIds,
+        )
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun onJoinChat(event: ChatParticipantsJoinedEvent) {
+        updateChatForUsers(
+            chatId = event.chatId,
+            userIds = event.userIds.toList(),
+        )
 
         broadcastToChat(
             chatId = event.chatId,

--- a/chat/src/main/kotlin/com/cpcjrcoding/chirp/domain/events/ChatCreatedEvent.kt
+++ b/chat/src/main/kotlin/com/cpcjrcoding/chirp/domain/events/ChatCreatedEvent.kt
@@ -1,0 +1,9 @@
+package com.cpcjrcoding.chirp.domain.events
+
+import com.cpcjrcoding.chirp.domain.type.ChatId
+import com.cpcjrcoding.chirp.domain.type.UserId
+
+data class ChatCreatedEvent(
+    val chatId: ChatId,
+    val participantIds: List<UserId>,
+)

--- a/chat/src/main/kotlin/com/cpcjrcoding/chirp/infra/database/entities/ChatMessageEntity.kt
+++ b/chat/src/main/kotlin/com/cpcjrcoding/chirp/infra/database/entities/ChatMessageEntity.kt
@@ -5,8 +5,6 @@ import com.cpcjrcoding.chirp.domain.type.ChatMessageId
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
@@ -30,7 +28,6 @@ import java.time.Instant
 )
 class ChatMessageEntity(
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
     var id: ChatMessageId? = null,
     @Column(nullable = false)
     var content: String,

--- a/chat/src/main/kotlin/com/cpcjrcoding/chirp/service/ChatMessageService.kt
+++ b/chat/src/main/kotlin/com/cpcjrcoding/chirp/service/ChatMessageService.kt
@@ -21,6 +21,7 @@ import org.springframework.cache.annotation.CacheEvict
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import java.util.UUID
 
 @Service
 class ChatMessageService(
@@ -29,6 +30,7 @@ class ChatMessageService(
     private val chatParticipantRepository: ChatParticipantRepository,
     private val applicationEventPublisher: ApplicationEventPublisher,
     private val eventPublisher: EventPublisher,
+    private val messageCacheEvictionHelper: MessageCacheEvictionHelper,
 ) {
     @Transactional
     @CacheEvict(
@@ -51,7 +53,7 @@ class ChatMessageService(
         val savedMessage =
             chatMessageRepository.saveAndFlush(
                 ChatMessageEntity(
-                    id = messageId,
+                    id = messageId ?: UUID.randomUUID(),
                     content = content.trim(),
                     chatId = chatId,
                     chat = chat,
@@ -95,14 +97,6 @@ class ChatMessageService(
             ),
         )
 
-        evictMessagesCache(message.chatId)
-    }
-
-    @CacheEvict(
-        value = ["messages"],
-        key = "#chatId",
-    )
-    fun evictMessagesCache(chatId: ChatId) {
-        // NO-OP: Let Spring handle the cache evict
+        messageCacheEvictionHelper.evictMessagesCache(message.chatId)
     }
 }

--- a/chat/src/main/kotlin/com/cpcjrcoding/chirp/service/MessageCacheEvictionHelper.kt
+++ b/chat/src/main/kotlin/com/cpcjrcoding/chirp/service/MessageCacheEvictionHelper.kt
@@ -1,0 +1,16 @@
+package com.cpcjrcoding.chirp.service
+
+import com.cpcjrcoding.chirp.domain.type.ChatId
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.stereotype.Component
+
+@Component
+class MessageCacheEvictionHelper {
+    @CacheEvict(
+        value = ["messages"],
+        key = "#chatId",
+    )
+    fun evictMessagesCache(chatId: ChatId) {
+        // NO-OP: Let Spring handle the cache evict
+    }
+}

--- a/user/src/main/kotlin/com/cpcjrcoding/chirp/api/exceptionhandling/AuthExceptionHandler.kt
+++ b/user/src/main/kotlin/com/cpcjrcoding/chirp/api/exceptionhandling/AuthExceptionHandler.kt
@@ -50,7 +50,7 @@ class AuthExceptionHandler {
         )
 
     @ExceptionHandler(EmailNotVerifiedException::class)
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
     fun onEmailNotVerified(e: EmailNotVerifiedException) =
         mapOf(
             "code" to "EMAIL_NOT_VERIFIED",


### PR DESCRIPTION
- Introduces ChatCreatedEvent to handle chat creation events and updates ChatWebSocketHandler to process these events. Refactors message cache eviction logic into a new MessageCacheEvictionHelper component.
- Also changes email not verified response status from UNAUTHORIZED to FORBIDDEN and removes unused JPA annotations from ChatMessageEntity.